### PR TITLE
modify typeface name for Hack Dok derivative

### DIFF
--- a/source/Hack-Bold.ufo/fontinfo.plist
+++ b/source/Hack-Bold.ufo/fontinfo.plist
@@ -11,11 +11,11 @@
 	<key>descender</key>
 	<integer>-492</integer>
 	<key>familyName</key>
-	<string>Hack</string>
+	<string>Hack Dok</string>
 	<key>macintoshFONDFamilyID</key>
 	<integer>128</integer>
 	<key>macintoshFONDName</key>
-	<string>Hack</string>
+	<string>Hack Dok</string>
 	<key>note</key>
 	<string></string>
 	<key>openTypeHeadCreated</key>
@@ -30,7 +30,7 @@
 	<key>openTypeHheaLineGap</key>
 	<integer>0</integer>
 	<key>openTypeNameCompatibleFullName</key>
-	<string>Hack Bold</string>
+	<string>Hack Dok Bold</string>
 	<key>openTypeNameDescription</key>
 	<string></string>
 	<key>openTypeNameDesigner</key>
@@ -90,7 +90,7 @@ Except as contained in this notice, the names of Gnome, the Gnome Foundation, an
 	<key>openTypeNameManufacturerURL</key>
 	<string>https://github.com/source-foundry</string>
 	<key>openTypeNamePreferredFamilyName</key>
-	<string>Hack</string>
+	<string>Hack Dok</string>
 	<key>openTypeNamePreferredSubfamilyName</key>
 	<string>Bold</string>
 	<key>openTypeNameSampleText</key>
@@ -228,11 +228,11 @@ Except as contained in this notice, the names of Gnome, the Gnome Foundation, an
 		<integer>1520</integer>
 	</array>
 	<key>postscriptFontName</key>
-	<string>Hack-Bold</string>
+	<string>HackDok-Bold</string>
 	<key>postscriptForceBold</key>
 	<true/>
 	<key>postscriptFullName</key>
-	<string>Hack Bold</string>
+	<string>Hack Dok Bold</string>
 	<key>postscriptIsFixedPitch</key>
 	<true/>
 	<key>postscriptOtherBlues</key>
@@ -260,7 +260,7 @@ Except as contained in this notice, the names of Gnome, the Gnome Foundation, an
 	<key>postscriptUniqueID</key>
 	<integer>-1</integer>
 	<key>styleMapFamilyName</key>
-	<string>Hack</string>
+	<string>Hack Dok</string>
 	<key>styleMapStyleName</key>
 	<string>bold</string>
 	<key>styleName</key>

--- a/source/Hack-BoldItalic.ufo/fontinfo.plist
+++ b/source/Hack-BoldItalic.ufo/fontinfo.plist
@@ -11,13 +11,13 @@
 	<key>descender</key>
 	<integer>-492</integer>
 	<key>familyName</key>
-	<string>Hack</string>
+	<string>Hack Dok</string>
 	<key>italicAngle</key>
 	<real>-11</real>
 	<key>macintoshFONDFamilyID</key>
 	<integer>128</integer>
 	<key>macintoshFONDName</key>
-	<string>Hack</string>
+	<string>Hack Dok</string>
 	<key>note</key>
 	<string></string>
 	<key>openTypeHeadCreated</key>
@@ -32,7 +32,7 @@
 	<key>openTypeHheaLineGap</key>
 	<integer>0</integer>
 	<key>openTypeNameCompatibleFullName</key>
-	<string>Hack Bold Italic</string>
+	<string>Hack Dok Bold Italic</string>
 	<key>openTypeNameDescription</key>
 	<string></string>
 	<key>openTypeNameDesigner</key>
@@ -92,7 +92,7 @@ Except as contained in this notice, the names of Gnome, the Gnome Foundation, an
 	<key>openTypeNameManufacturerURL</key>
 	<string>https://github.com/source-foundry</string>
 	<key>openTypeNamePreferredFamilyName</key>
-	<string>Hack</string>
+	<string>Hack Dok</string>
 	<key>openTypeNamePreferredSubfamilyName</key>
 	<string>Bold Italic</string>
 	<key>openTypeNameSampleText</key>
@@ -228,11 +228,11 @@ Except as contained in this notice, the names of Gnome, the Gnome Foundation, an
 		<integer>1520</integer>
 	</array>
 	<key>postscriptFontName</key>
-	<string>Hack-BoldItalic</string>
+	<string>HackDok-BoldItalic</string>
 	<key>postscriptForceBold</key>
 	<true/>
 	<key>postscriptFullName</key>
-	<string>Hack Bold Italic</string>
+	<string>Hack Dok Bold Italic</string>
 	<key>postscriptIsFixedPitch</key>
 	<true/>
 	<key>postscriptOtherBlues</key>
@@ -261,7 +261,7 @@ Except as contained in this notice, the names of Gnome, the Gnome Foundation, an
 	<key>postscriptUniqueID</key>
 	<integer>-1</integer>
 	<key>styleMapFamilyName</key>
-	<string>Hack</string>
+	<string>Hack Dok</string>
 	<key>styleMapStyleName</key>
 	<string>bold italic</string>
 	<key>styleName</key>

--- a/source/Hack-Italic.ufo/fontinfo.plist
+++ b/source/Hack-Italic.ufo/fontinfo.plist
@@ -11,13 +11,13 @@
 	<key>descender</key>
 	<integer>-492</integer>
 	<key>familyName</key>
-	<string>Hack</string>
+	<string>Hack Dok</string>
 	<key>italicAngle</key>
 	<real>-11</real>
 	<key>macintoshFONDFamilyID</key>
 	<integer>128</integer>
 	<key>macintoshFONDName</key>
-	<string>Hack</string>
+	<string>Hack Dok</string>
 	<key>note</key>
 	<string></string>
 	<key>openTypeHeadCreated</key>
@@ -32,7 +32,7 @@
 	<key>openTypeHheaLineGap</key>
 	<integer>0</integer>
 	<key>openTypeNameCompatibleFullName</key>
-	<string>Hack Italic</string>
+	<string>Hack Dok Italic</string>
 	<key>openTypeNameDescription</key>
 	<string></string>
 	<key>openTypeNameDesigner</key>
@@ -92,7 +92,7 @@ Except as contained in this notice, the names of Gnome, the Gnome Foundation, an
 	<key>openTypeNameManufacturerURL</key>
 	<string>https://github.com/source-foundry</string>
 	<key>openTypeNamePreferredFamilyName</key>
-	<string>Hack</string>
+	<string>Hack Dok</string>
 	<key>openTypeNamePreferredSubfamilyName</key>
 	<string>Italic</string>
 	<key>openTypeNameSampleText</key>
@@ -227,11 +227,11 @@ Except as contained in this notice, the names of Gnome, the Gnome Foundation, an
 		<integer>1520</integer>
 	</array>
 	<key>postscriptFontName</key>
-	<string>Hack-Italic</string>
+	<string>HackDok-Italic</string>
 	<key>postscriptForceBold</key>
 	<false/>
 	<key>postscriptFullName</key>
-	<string>Hack Italic</string>
+	<string>Hack Dok Italic</string>
 	<key>postscriptIsFixedPitch</key>
 	<true/>
 	<key>postscriptOtherBlues</key>
@@ -259,7 +259,7 @@ Except as contained in this notice, the names of Gnome, the Gnome Foundation, an
 	<key>postscriptUniqueID</key>
 	<integer>-1</integer>
 	<key>styleMapFamilyName</key>
-	<string>Hack</string>
+	<string>Hack Dok</string>
 	<key>styleMapStyleName</key>
 	<string>italic</string>
 	<key>styleName</key>

--- a/source/Hack-Regular.ufo/fontinfo.plist
+++ b/source/Hack-Regular.ufo/fontinfo.plist
@@ -11,11 +11,11 @@
 	<key>descender</key>
 	<integer>-492</integer>
 	<key>familyName</key>
-	<string>Hack</string>
+	<string>Hack Dok</string>
 	<key>macintoshFONDFamilyID</key>
 	<integer>128</integer>
 	<key>macintoshFONDName</key>
-	<string>Hack</string>
+	<string>Hack Dok</string>
 	<key>note</key>
 	<string></string>
 	<key>openTypeHeadCreated</key>
@@ -30,7 +30,7 @@
 	<key>openTypeHheaLineGap</key>
 	<integer>0</integer>
 	<key>openTypeNameCompatibleFullName</key>
-	<string>Hack Regular</string>
+	<string>Hack Dok Regular</string>
 	<key>openTypeNameDescription</key>
 	<string></string>
 	<key>openTypeNameDesigner</key>
@@ -90,7 +90,7 @@ Except as contained in this notice, the names of Gnome, the Gnome Foundation, an
 	<key>openTypeNameManufacturerURL</key>
 	<string>https://github.com/source-foundry</string>
 	<key>openTypeNamePreferredFamilyName</key>
-	<string>Hack</string>
+	<string>Hack Dok</string>
 	<key>openTypeNamePreferredSubfamilyName</key>
 	<string>Regular</string>
 	<key>openTypeNameSampleText</key>
@@ -229,11 +229,11 @@ Except as contained in this notice, the names of Gnome, the Gnome Foundation, an
 		<integer>1520</integer>
 	</array>
 	<key>postscriptFontName</key>
-	<string>Hack-Regular</string>
+	<string>HackDok-Regular</string>
 	<key>postscriptForceBold</key>
 	<false/>
 	<key>postscriptFullName</key>
-	<string>Hack Regular</string>
+	<string>Hack Dok Regular</string>
 	<key>postscriptIsFixedPitch</key>
 	<true/>
 	<key>postscriptOtherBlues</key>
@@ -260,7 +260,7 @@ Except as contained in this notice, the names of Gnome, the Gnome Foundation, an
 	<key>postscriptUniqueID</key>
 	<integer>-1</integer>
 	<key>styleMapFamilyName</key>
-	<string>Hack</string>
+	<string>Hack Dok</string>
 	<key>styleMapStyleName</key>
 	<string>regular</string>
 	<key>styleName</key>


### PR DESCRIPTION
This should transition fonts built with the source from the name "Hack" to the name "Hack Dok". 

The same files can be modified to create a new versioning scheme, updated license for your downstream changes, etc.  

Good luck with this fork Ennio!